### PR TITLE
Increase command timeout to successfully provision CentOS boxes.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -53,6 +53,7 @@ node /^centos-7-0/ {
 
   exec { 'update-rpm-packages':
     command => '/usr/bin/yum update -y',
+    timeout => 1800
   }
 
   package {'epel-release':
@@ -95,6 +96,7 @@ node /^centos/ {
   exec { 'update-rpm-packages':
     command => '/usr/bin/yum update -y',
     creates => '/vagrant/.locks/update-rpm-packages',
+    timeout => 1800
   }
 
   package {'epel-release':


### PR DESCRIPTION
Signed-off-by: GabrielNicolasAvellaneda avellaneda.gabriel@gmail.com
